### PR TITLE
feat: added automatic testing via GH actions with logging (relates to…

### DIFF
--- a/.github/workflows/log-tests.yml
+++ b/.github/workflows/log-tests.yml
@@ -1,0 +1,37 @@
+name: Test Logging service  
+
+on:
+  push:
+    paths:
+      - "algorithms/**"
+      - "tests/**"
+      - ".github/workflows/**"
+
+
+jobs:
+  log_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest coverage 
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests with coverage
+        run: |
+          echo "======================================="
+          echo "               TEST LOGS"
+          echo "======================================="
+          echo ""
+          python -m coverage run -m pytest  tests
+          echo ""
+          echo "======================================="
+          echo "            COVEARGE REPORT"
+          echo "======================================="
+          echo ""
+          python -m coverage report 


### PR DESCRIPTION
Made a logging service that is based upon Github actions.

The initial idea of generating JSON logs that we could view as artifacts were scrapped, as Github does not have the ability to serve artifacts in the UI. Instead, I opted for just producing logs in the test output as those are easy to view in the UI, while still being able to download the logs and search through them.

- The job only runs on pushes to the `/tests`, `/algorithms`, `.github/workflows` folders not to produce that many logs. 
- It runs `pytest` and `Coverage.py`

**You can find/view/download logs from here**
![chrome_MZBGpHbbmo](https://user-images.githubusercontent.com/66034456/156585211-9b3dd5f8-b786-4365-8d62-918270aea2a5.gif)

---
closes #8

