### PR TITLE
Fix latex elems

### DIFF
--- a/report.md
+++ b/report.md
@@ -80,7 +80,7 @@ Let's have a look on the dynamic programming formula. The table storing the inte
 
 And so the formula goes as follow:
 
-`countWaysUntil(mask, k_hat) = countWaysUntil(mask, k_hat + 1) + `[http://latex.codecogs.com/svg.latex?\sum_{i=0}^{n}](http://latex.codecogs.com/svg.latex?\sum_{i=0}^{n})` countWaysUntil(mask | (1 << i), k_hat + 1)`
+`countWaysUntil(mask, k_hat) = countWaysUntil(mask, k_hat + 1) + `![\sum_{i=0}^{n}](http://latex.codecogs.com/svg.latex?%5csum_%7bi%3d0%7d%5e%7bn%7d)` countWaysUntil(mask | (1 << i), k_hat + 1)`
 
 More specifically, this formula says that the number of ways satisfying the problem for a specific mask (i.e. hat wearing status of the people) and taking into account all hats from the _k-th_ one until hat $N$ is defined by the sum of
 

--- a/report.md
+++ b/report.md
@@ -80,7 +80,7 @@ Let's have a look on the dynamic programming formula. The table storing the inte
 
 And so the formula goes as follow:
 
-`countWaysUntil(mask, k_hat) = countWaysUntil(mask, k_hat + 1) + `<img src="http://latex.codecogs.com/svg.latex?\sum_{i=0}^{n}" title="http://latex.codecogs.com/svg.latex?\sum_{i=0}^{n}" />` countWaysUntil(mask | (1 << i), k_hat + 1)`
+`countWaysUntil(mask, k_hat) = countWaysUntil(mask, k_hat + 1) + `[http://latex.codecogs.com/svg.latex?\sum_{i=0}^{n}](http://latex.codecogs.com/svg.latex?\sum_{i=0}^{n})` countWaysUntil(mask | (1 << i), k_hat + 1)`
 
 More specifically, this formula says that the number of ways satisfying the problem for a specific mask (i.e. hat wearing status of the people) and taking into account all hats from the _k-th_ one until hat $N$ is defined by the sum of
 

--- a/report.md
+++ b/report.md
@@ -80,7 +80,7 @@ Let's have a look on the dynamic programming formula. The table storing the inte
 
 And so the formula goes as follow:
 
-`countWaysUntil(mask, k_hat) = countWaysUntil(mask, k_hat + 1) + `$\sum_{i=0}^{n}$` countWaysUntil(mask | (1 << i), k_hat + 1)`
+`countWaysUntil(mask, k_hat) = countWaysUntil(mask, k_hat + 1) + `<img src="http://latex.codecogs.com/svg.latex?\sum_{i=0}^{n}" title="http://latex.codecogs.com/svg.latex?\sum_{i=0}^{n}" />` countWaysUntil(mask | (1 << i), k_hat + 1)`
 
 More specifically, this formula says that the number of ways satisfying the problem for a specific mask (i.e. hat wearing status of the people) and taking into account all hats from the _k-th_ one until hat $N$ is defined by the sum of
 

--- a/report.md
+++ b/report.md
@@ -75,8 +75,8 @@ In our case, bitmasking will be used to represent whether a person is wearing a 
 
 Let's have a look on the dynamic programming formula. The table storing the intermediate results is a $M\times N$ matrix where:
 
-- $M$ is the total number of masks, which is equal to $2^n$ where $n$ is the number of people
-- $N$ is the total number of hats
+- M is the total number of masks, which is equal to ![\2^{n}](http://latex.codecogs.com/svg.latex?2%5e%7bn%7d) where n is the number of people
+- N is the total number of hats
 
 And so the formula goes as follow:
 

--- a/report.md
+++ b/report.md
@@ -73,7 +73,7 @@ To solve this problem, we will use bitmasking and dynamic programming. Bitmaskin
 
 In our case, bitmasking will be used to represent whether a person is wearing a hat. In other words, a _i-th_ bit set to 1 means that the _i-th_ person is wearing a hat. Therefore the final cases we're interested into are the ones when the mask is completely full, i.e. all bits are set to 1.
 
-Let's have a look on the dynamic programming formula. The table storing the intermediate results is a $M\times N$ matrix where:
+Let's have a look on the dynamic programming formula. The table storing the intermediate results is a ![M\times N](http://latex.codecogs.com/svg.latex?M%5ctimes%20N) matrix where:
 
 - M is the total number of masks, which is equal to ![\2^{n}](http://latex.codecogs.com/svg.latex?2%5e%7bn%7d) where n is the number of people
 - N is the total number of hats


### PR DESCRIPTION
This pull requests takes care of (mostly) the issue with latex not working for the math in the github repo. Unfortunately it turns out that github does not support the inclusion of latex and such the mathematical formulas must be included as linked images. This means that they do not change colour when the user's github theme is changed. I've decided to stick with the black colour as it matches with the text when githubs default themed is used. 

Should close issue #48 