### PR TITLE
Increase coverage

### DIFF
--- a/report.md
+++ b/report.md
@@ -60,6 +60,14 @@ Each of the following requirements will be linked to new tests, since no tests r
 | R1.2 |              Person without caps              |                                                         If there is at least one person that doesn't have any caps, there should be 0 ways to assign the caps. |
 | R1.3 |           No unique cap assignment            |                                  Assume there are >0 people and at least one cap per person. If there is no unique assignment of caps, the output should be 0. |
 | R1.4 |      One or more unique cap assignments       |                       Assume there are >0 people and at least one cap per person. If there is at least one unique assignment of caps, the output should be >0. |
+| R1.5 |               Too many people                 |                                                                       If there are too many people (i.e. capSets) then a ValueError should be raised.
+|
+| R1.6 |               Faulty CapIds                   |                                                                       If any of the cap Ids are not given as an integer a ValueError should be raised.
+| 
+| R1.7 |            Faulty collection input            |                                                                   If the cap ids are given as another collection type than a list and error should be raised.
+|
+| R1.8 |            CapId too low                      |                                                         If the provided maximum capId is lower than the highest given cap id this should raise a value error.
+|
 | R2.1 |                   No nodes                    |                                                                                                        If the nr of nodes is 0, a ValueError should be raised. |
 | R2.2 |                   One node                    |                                                                                                               If the nr of nodes is 1, the output should be 0. |
 | R2.3 |             Positive path length              | If there are at least two nodes that are >0 length units apart, the output should be a number >0 that corresponds to the length of the shortest Euler circuit. |

--- a/report.md
+++ b/report.md
@@ -73,6 +73,12 @@ Each of the following requirements will be linked to new tests, since no tests r
 | R2.3 |             Positive path length              | If there are at least two nodes that are >0 length units apart, the output should be a number >0 that corresponds to the length of the shortest Euler circuit. |
 | R2.4 |                  No solution                  |                                  If the nr of nodes is >1 and there is at least one node that cannot be reached from any other node, the output should be inf. |
 | R2.5 |               Faulty dimensions               |                                              If the dimensions of the given graph don't correspond to the dimension parameters, a ValueError should be raised. |
+| R2.6 |                Wrong collection type          |                                                    If the collection of nodes is not a list a ValueError should be raised.
+| 
+| R2.7 |                Wrong node type                |                                                   If a node in the collection is of the wrong type a ValueError should be raised.
+| 
+| R2.8 |               Too many houses                 |                                                   Checks that a value error is raised if too many houses are allocated in the input matrix. 
+| 
 
 
 ## Algorithm description

--- a/tests/test_dp.py
+++ b/tests/test_dp.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 from algorithms.dp import (
     assign_unique_caps,
     tsp,
@@ -51,6 +52,30 @@ class TestBitmaskingCapAssignment(unittest.TestCase):
     # unique assignments) when the cap sets allow for at least one unique assignment.
     def test_one_or_more_unique_cap_assignments(self):
         self.assertEquals(assign_unique_caps([[1,2,3], [4], [1,2]], 6), 4)
+    
+    # === Relates to requirement R1.5 "Too Many People" ===
+    # Checks that if the amount of people (i.e. cap sets) are too large we raise a value error.
+    def test_too_many_people(self):
+        with self.assertRaises(ValueError):
+            assign_unique_caps([[1],[2],[3],[4],[5],[6],[7],[8],[9],[10],[11]],11)    
+
+    # === Relates to requirement R1.6 "Faulty CapIds" ===
+    # Checks that if one of the cap ids are supplied in the wrong format a value error is raised.
+    def test_faulty_string(self):
+        with self.assertRaises(ValueError):
+            assign_unique_caps([[1],['2']],2)
+    
+    # === Relates to requirement R1.7 "Faulty collection input" ===
+    # Checks that a value error is raised when the list of caps is provided as the wrong type of collection.
+    def test_faulty_collection(self):
+        with self.assertRaises(ValueError):
+            assign_unique_caps([[1],{2}],2)
+
+     # === Relates to requirement R1.8 "CapId too low" ===
+    # Checks that the highest supplied capId matches the cap with the highest id.
+    def test_too_many_sets(self):
+        with self.assertRaises(ValueError):
+            assign_unique_caps([[1],[2]],1)
         
 class TestBitmaskingTSP(unittest.TestCase):
     # === Relates to requirement R2.1 "No nodes" ===

--- a/tests/test_dp.py
+++ b/tests/test_dp.py
@@ -143,11 +143,40 @@ class TestBitmaskingTSP(unittest.TestCase):
         with self.assertRaises(ValueError):
             tsp(nodes, nbRow, nbColumn)
         
-    # === Relates to requirement R2.4 "No solution" ===
-    # Checks that the output is inf when there is at least one unreachable node 
-    def test_no_solution(self):
-        # TODO
-        pass
+    # === Relates to requirement R2.6 "Wrong collection type" ===
+    # Checks that a value error is raised when the collection of nodes is of the wrong type.
+    def test_wrong_collection_type(self):
+        nodes = [
+            {'.', '.', '.', '.', '.', '.', '*'}
+        ]
+        nbRow = 1
+        nbColumn = 7
+        with self.assertRaises(ValueError):
+            tsp(nodes, nbRow, nbColumn)
+    
+    # === Relates to requirement R2.7 "Wrong node type" ===
+    # Checks that a value error is raised when a node is of the wrong type.
+    def test_wrong_node_type(self):
+        nodes = [
+            ['.', '.', '.', '.', '.', 'X', '*']
+        ]
+        nbRow = 1
+        nbColumn = 7
+        with self.assertRaises(ValueError):
+            tsp(nodes, nbRow, nbColumn)
+
+    # === Relates to requirement R2.8 "Too many houses" ===
+    # Checks that a value error is raised when too many houses are provided.
+    def test_too_many_houses(self):
+        nodes = [
+            ['*', '*', '*', '*', '*', '*', '*'],
+            ['*', '*', '*', '*', '*', '*', '*']
+        ]
+        nbRow = 2
+        nbColumn = 7
+        with self.assertRaises(ValueError):
+            tsp(nodes, nbRow, nbColumn)
+    
         
 class TestBuySellStock(unittest.TestCase):
     def test_max_profit_naive(self):


### PR DESCRIPTION
This branch contains new requirements and tests for the bitmasking cap_assignment and the bitmasking_tsp implementations. Coverage have been raised from 85%-> 92% for bitmasking cap_assignment and from 89%->94% for bitmasking_tsp. It's as close as I could get with the coverage tool and should suffice even if it's not 100%.